### PR TITLE
Remove create stake pool unused destination

### DIFF
--- a/frontend/src/pages/CreatePool.tsx
+++ b/frontend/src/pages/CreatePool.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import Card from "../components/Card";
 import { styled } from "@mui/material/styles";
 import { createStakePool, ACCESS_PROGRAM_ID, StakePool } from "@access";
@@ -8,7 +8,6 @@ import FormControl from "@mui/material/FormControl";
 import InputLabel from "@mui/material/InputLabel";
 import OutlinedInput from "@mui/material/OutlinedInput";
 import { Button } from "@mui/material";
-import { PublicKey } from "@solana/web3.js";
 import { sendTx } from "../utils/send";
 import { notify } from "../utils/notifications";
 
@@ -46,20 +45,18 @@ const FormControlStyled = styled(FormControl)({
 
 const CreatePool = () => {
   const { connection } = useConnection();
-  const { publicKey, sendTransaction } = useWallet();
+  const { connected, publicKey, sendTransaction } = useWallet();
   const [loading, setLoading] = useState(false);
-  const [minimum, setMinimum] = useState<null | number>(null);
-  const [destination, setDestination] = useState<string | null>(null);
+  const [minimum, setMinimum] = useState<number>(0);
   const [stakePool, setStakePool] = useState<string | null>(null);
 
   const handle = async () => {
-    if (!publicKey || !minimum || !destination) return;
+    if (!publicKey || !minimum) return;
     try {
       setLoading(true);
       const ix = await createStakePool(
         connection,
         publicKey,
-        new PublicKey(destination),
         minimum,
         publicKey,
         ACCESS_PROGRAM_ID
@@ -85,16 +82,6 @@ const CreatePool = () => {
         <Card>
           <InnerCard>
             <FormControlStyled>
-              <InputLabel>Rewards destination</InputLabel>
-              <OutlinedInput
-                type="text"
-                id="component-outlined"
-                value={destination}
-                onChange={(e) => setDestination(e.target.value.trim())}
-                label="Rewards destination"
-              />
-            </FormControlStyled>
-            <FormControlStyled>
               <InputLabel>Minimum stake amount</InputLabel>
               <OutlinedInput
                 type="number"
@@ -104,7 +91,7 @@ const CreatePool = () => {
                 label="Minimum stake amount"
               />
             </FormControlStyled>
-            <Button variant="contained" onClick={handle}>
+            <Button disabled={!connected} variant="contained" onClick={handle}>
               {loading ? <CircularProgress color="inherit" /> : "Create"}
             </Button>
             {stakePool && (

--- a/smart-contract/js/src/bindings.ts
+++ b/smart-contract/js/src/bindings.ts
@@ -443,7 +443,6 @@ export const createStakeAccount = async (
 export const createStakePool = async (
   connection: Connection,
   owner: PublicKey,
-  destination: PublicKey,
   minimumStakeAmount: number,
   feePayer: PublicKey,
   programId: PublicKey


### PR DESCRIPTION
This PR is removing unused code for create stake pool code. Specifically it removes `destination` argument as it's not used.