### PR TITLE
Fix createStakePool arguments mismatch

### DIFF
--- a/frontend/src/pages/CreatePool.tsx
+++ b/frontend/src/pages/CreatePool.tsx
@@ -59,7 +59,6 @@ const CreatePool = () => {
       const ix = await createStakePool(
         connection,
         publicKey,
-        new PublicKey(destination),
         minimum,
         publicKey,
         ACCESS_PROGRAM_ID


### PR DESCRIPTION
This correcting JS example with incorrect arguments matches the smart contract and its arguments.