### PR TITLE
Allow the staker to stake more right after the first stake

### DIFF
--- a/smart-contract/program/src/processor/stake.rs
+++ b/smart-contract/program/src/processor/stake.rs
@@ -2,19 +2,17 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
-    clock::Clock,
     entrypoint::ProgramResult,
     msg,
     program::invoke,
     program_error::ProgramError,
     pubkey::Pubkey,
-    sysvar::Sysvar,
 };
 
 use spl_token::instruction::transfer;
 
 use crate::{
-    state::{CentralState, Tag, FEES, SECONDS_IN_DAY},
+    state::{CentralState, Tag, FEES},
     utils::{assert_valid_fee, check_account_key, check_account_owner, check_signer},
 };
 use bonfida_utils::{BorshSize, InstructionsAccount};


### PR DESCRIPTION
This is a request for comments (ARC - Access Request for Comments)

I've encountered one scenario when staking:

**Current issue:**
As a staker 
When I stake min amount
And if I decide to stake more
I'm not allowed to stake more because of 24h waiting period (crank time is less than my claim time therefore there's no reward yet and I have free tokens to stake)

**Proposed flow**:
As a staker
When I stake min. amount
And I'll try to stake again right after
Then I should be allowed to stake even more if there's no reward (ie. cranked time is less than my claim time)

This PR proposes to change the stake instruction to allow the user to stake more if there's no reward (ie. crank time is less than claim time). This will also be aligned with unstake instruction that already works like this.

If this is not feasible I'll have to tell the user that there's 24h waiting period before he can stake again (bummer). Also, an explanation of why the 24h measure is so important would be appreciated.