### PR TITLE
Change SECONDS_IN_DAY to be 15min and UNSTAKE_PERIOD 1s

### DIFF
--- a/smart-contract/program/src/state.rs
+++ b/smart-contract/program/src/state.rs
@@ -21,7 +21,7 @@ pub const ACCESS_MINT: Pubkey =
 
 #[allow(missing_docs)]
 pub const SECONDS_IN_DAY: u64 = if cfg!(feature = "days-to-sec") {
-    10
+    15 * 60
 } else {
     3600 * 24
 };
@@ -35,8 +35,8 @@ pub const OWNER_MULTIPLIER: u64 = 100 - STAKER_MULTIPLIER;
 /// Length of the circular buffer (stores balances for 1 year)
 pub const STAKE_BUFFER_LEN: u64 = 274; // 9 Months
 
-/// Default unstake period set to 7 days
-pub const UNSTAKE_PERIOD: i64 = 7 * SECONDS_IN_DAY as i64;
+/// Default unstake period set to 1 sec
+pub const UNSTAKE_PERIOD: i64 = 1;
 
 /// Max pending unstake requests
 pub const MAX_UNSTAKE_REQUEST: usize = 10;


### PR DESCRIPTION
I like to propose some changes to the current constant values in the smart contract code.

1) Change SECONDS_IN_DAY from 10s to 15m (ie. 15 * 60) which will allow us to have max. buffer size of 274 days is stretched to at least 2 days without cranking. With the current 10s day, we're not able to claim rewards for the staking pool as cranking the pool after 274 days (in our case 274 * 10s ~ 45min.) results in 0 rewards therefore an unclaimable state, unstakable state and the user is not able to recover from this. Essentially the pool is stuck. If modifying the alg. would be better I would appreciate help with that.

2) Change the UNSTAKE_PERIOD to just 1s. Mika requests this because we want to have unstake period present in the code, but we don't want to use it for now. Essentially we want the user to be able to run both transactions (unstake, execute unstake requests) in the same session.

Thank you, again for your consideration and help.