### PR TITLE
Do not allow claiming of bond rewards

### DIFF
--- a/smart-contract/program/src/instruction.rs
+++ b/smart-contract/program/src/instruction.rs
@@ -1,6 +1,8 @@
 pub use crate::processor::{
     activate_stake_pool, admin_freeze, admin_mint, change_inflation, change_pool_minimum,
-    change_pool_multiplier, claim_bond, claim_bond_rewards, claim_pool_rewards, claim_rewards,
+    change_pool_multiplier, claim_bond, 
+    //claim_bond_rewards, 
+    claim_pool_rewards, claim_rewards,
     close_stake_account, close_stake_pool, crank, create_bond, create_central_state,
     create_stake_account, create_stake_pool, execute_unstake, sign_bond, stake, unlock_bond_tokens,
     unstake,
@@ -197,7 +199,7 @@ pub enum ProgramInstruction {
     /// | 4     | ❌        | ❌      | The central state account            |
     /// | 5     | ✅        | ❌      | The mint address of the ACCESS token |
     /// | 6     | ❌        | ❌      | The SPL token program account        |
-    ClaimBondRewards,
+    // ClaimBondRewards,
     /// Change the minimum stakeable amount of a pool
     /// This instruction allows a pool owner to adjust the price of its subscription for new joiners without impacting people who already subscribed
     ///
@@ -380,18 +382,18 @@ pub fn claim_bond(
 ) -> Instruction {
     accounts.get_instruction(program_id, ProgramInstruction::ClaimBond as u8, params)
 }
-#[allow(missing_docs)]
-pub fn claim_bond_rewards(
-    program_id: Pubkey,
-    accounts: claim_bond_rewards::Accounts<Pubkey>,
-    params: claim_bond_rewards::Params,
-) -> Instruction {
-    accounts.get_instruction(
-        program_id,
-        ProgramInstruction::ClaimBondRewards as u8,
-        params,
-    )
-}
+// #[allow(missing_docs)]
+// pub fn claim_bond_rewards(
+//     program_id: Pubkey,
+//     accounts: claim_bond_rewards::Accounts<Pubkey>,
+//     params: claim_bond_rewards::Params,
+// ) -> Instruction {
+//     accounts.get_instruction(
+//         program_id,
+//         ProgramInstruction::ClaimBondRewards as u8,
+//         params,
+//     )
+// }
 #[allow(missing_docs)]
 pub fn change_pool_minimum(
     program_id: Pubkey,

--- a/smart-contract/program/src/processor.rs
+++ b/smart-contract/program/src/processor.rs
@@ -13,7 +13,7 @@ pub mod change_inflation;
 pub mod change_pool_minimum;
 pub mod change_pool_multiplier;
 pub mod claim_bond;
-pub mod claim_bond_rewards;
+// pub mod claim_bond_rewards;
 pub mod claim_pool_rewards;
 pub mod claim_rewards;
 pub mod close_stake_account;
@@ -140,12 +140,12 @@ impl Processor {
                     .map_err(|_| ProgramError::InvalidInstructionData)?;
                 claim_bond::process_claim_bond(program_id, accounts, params)?;
             }
-            ProgramInstruction::ClaimBondRewards => {
-                msg!("Instruction: claim bond rewards");
-                let params = claim_bond_rewards::Params::try_from_slice(instruction_data)
-                    .map_err(|_| ProgramError::InvalidInstructionData)?;
-                claim_bond_rewards::process_claim_bond_rewards(program_id, accounts, params)?;
-            }
+            // ProgramInstruction::ClaimBondRewards => {
+            //     msg!("Instruction: claim bond rewards");
+            //     let params = claim_bond_rewards::Params::try_from_slice(instruction_data)
+            //         .map_err(|_| ProgramError::InvalidInstructionData)?;
+            //     claim_bond_rewards::process_claim_bond_rewards(program_id, accounts, params)?;
+            // }
             ProgramInstruction::ChangePoolMinimum => {
                 msg!("Instruction: Change pool minimum");
                 let params = change_pool_minimum::Params::try_from_slice(instruction_data)

--- a/smart-contract/program/tests/functional.rs
+++ b/smart-contract/program/tests/functional.rs
@@ -8,7 +8,9 @@ use access_protocol::{
     entrypoint::process_instruction,
     instruction::{
         activate_stake_pool, admin_freeze, admin_mint, change_inflation, change_pool_minimum,
-        change_pool_multiplier, claim_bond, claim_bond_rewards, claim_pool_rewards, claim_rewards,
+        change_pool_multiplier, claim_bond, 
+        // claim_bond_rewards,
+        claim_pool_rewards, claim_rewards,
         close_stake_account, close_stake_pool, crank, create_bond, create_central_state,
         create_stake_account, create_stake_pool, execute_unstake, stake, unlock_bond_tokens,
         unstake,
@@ -372,27 +374,27 @@ async fn test_staking() {
     // Claim bond rewards
     //
 
-    let claim_bond_rewards_ix = claim_bond_rewards(
-        program_id,
-        claim_bond_rewards::Accounts {
-            stake_pool: &stake_pool_key,
-            bond_account: &bond_key,
-            bond_owner: &staker.pubkey(),
-            rewards_destination: &staker_token_acc,
-            central_state: &central_state,
-            mint: &mint,
-            spl_token_program: &spl_token::ID,
-        },
-        claim_bond_rewards::Params {},
-    );
+    // let claim_bond_rewards_ix = claim_bond_rewards(
+    //     program_id,
+    //     claim_bond_rewards::Accounts {
+    //         stake_pool: &stake_pool_key,
+    //         bond_account: &bond_key,
+    //         bond_owner: &staker.pubkey(),
+    //         rewards_destination: &staker_token_acc,
+    //         central_state: &central_state,
+    //         mint: &mint,
+    //         spl_token_program: &spl_token::ID,
+    //     },
+    //     claim_bond_rewards::Params {},
+    // );
 
-    sign_send_instructions(
-        &mut prg_test_ctx,
-        vec![claim_bond_rewards_ix],
-        vec![&staker],
-    )
-    .await
-    .unwrap();
+    // sign_send_instructions(
+    //     &mut prg_test_ctx,
+    //     vec![claim_bond_rewards_ix],
+    //     vec![&staker],
+    // )
+    // .await
+    // .unwrap();
 
     //
     // Claim rewards


### PR DESCRIPTION
We want to turn off the rewards claiming for bonds. We only want the bonds to be unlockable yet should not yield any rewards. This is the fastest solution with commenting out the claim bond rewards entry point.