### PR TITLE
Prevent unlock period to be 0 on bond accounts

### DIFF
--- a/smart-contract/program/src/entrypoint.rs
+++ b/smart-contract/program/src/entrypoint.rs
@@ -147,6 +147,9 @@ impl PrintProgramError for AccessError {
                 msg!("Error: Pending unstake request")
             }
             AccessError::CannotStakeZero => { msg!("Cannot stake 0 token")}
+            AccessError::ForbiddenUnlockPeriodZero => { 
+                msg!("Unlock period cannot be 0")
+            }
         }
     }
 }

--- a/smart-contract/program/src/error.rs
+++ b/smart-contract/program/src/error.rs
@@ -82,7 +82,9 @@ pub enum AccessError {
     #[error("Pending unstake request")]
     PendingUnstakeRequests,
     #[error("Cannot stake 0 token")]
-    CannotStakeZero
+    CannotStakeZero,
+    #[error("Unlock period cannot be 0")]
+    ForbiddenUnlockPeriodZero
 }
 
 impl From<AccessError> for ProgramError {

--- a/smart-contract/program/src/processor/create_bond.rs
+++ b/smart-contract/program/src/processor/create_bond.rs
@@ -116,6 +116,10 @@ pub fn process_create_bond(
     #[cfg(not(feature = "no-bond-signer"))]
     assert_authorized_seller(accounts.seller, params.seller_index as usize)?;
 
+    if params.unlock_period == 0 {
+        return Err(AccessError::ForbiddenUnlockPeriodZero.into());
+    }
+
     let bond = BondAccount::new(
         params.buyer,
         params.total_amount_sold,


### PR DESCRIPTION
Problem:
When creating bond accounts user/admin can put 0 for unlock period. This is a very intuitive entry if you want no unlock period, yet the program will not allow tokens to be unlocked (unlock_bond_tokens.rs:148) as it divided the delta by unlock_period causing division by 0 and therefore overflow error.

Possible solution (this PR):
I've added a check to create_bond.rs endpoint to not allow users to create bonds with unlock period set to 0 to prevent the division by 0. 

Another possible solution:
Would be to check the unlock period against 0 during the unlock bond tokens execution.

Thank you.