### PR TITLE
[AP-90] New deployment pre-production defaults

### DIFF
--- a/smart-contract/program/src/lib.rs
+++ b/smart-contract/program/src/lib.rs
@@ -57,4 +57,4 @@ pub(crate) mod utils;
 #[allow(missing_docs)]
 pub mod cpi;
 
-declare_id!("FuGuhWkaMCWfk2sg3VsxTL39zurSNQgtCV5zjFcVaTio");
+declare_id!("acp1VPqNoMs5KC5aEH3MzxnyPZNyKQF1TCPouCoNRuX");

--- a/smart-contract/program/src/state.rs
+++ b/smart-contract/program/src/state.rs
@@ -18,7 +18,7 @@ use std::ops::DerefMut;
 
 /// ACCESS token mint
 pub const ACCESS_MINT: Pubkey =
-    solana_program::pubkey!("Hc4bdbupCMRkuP3o5gMks77ifACgVuxFAaUYbeuNoxG5");
+    solana_program::pubkey!("acsPVZqm4ykxKftWAKtDU7zbBNELffT9k7p5ZCrWJme");
 
 #[allow(missing_docs)]
 pub const SECONDS_IN_DAY: u64 = if cfg!(feature = "days-to-sec-15m") {

--- a/smart-contract/program/src/state.rs
+++ b/smart-contract/program/src/state.rs
@@ -45,7 +45,7 @@ pub const UNSTAKE_PERIOD: i64 = 1;
 pub const MAX_UNSTAKE_REQUEST: usize = 10;
 
 /// Fees charged on staking instruction in % (i.e FEES = 1 <-> 1% fee charged)
-pub const FEES: u64 = 1;
+pub const FEES: u64 = 2;
 
 #[derive(BorshSerialize, BorshDeserialize, BorshSize, PartialEq, FromPrimitive, ToPrimitive)]
 #[repr(u8)]


### PR DESCRIPTION
- The PROGRAM_ID (acp) and ACCESS_MINT (acs) are now vanity keys with prefixes.
- The fee is now 2%.
- Customise the createMint() function to allow us to pass custom mint keypair (spl-token=0.1.8 code in newer version you can pass it after decimals)